### PR TITLE
B6 Fixed fullscreen mouse pressed event

### DIFF
--- a/Game.gmx/objects/display_obj.object.gmx
+++ b/Game.gmx/objects/display_obj.object.gmx
@@ -35,7 +35,7 @@ display_init();
         </arguments>
       </action>
     </event>
-    <event eventtype="6" enumb="0">
+    <event eventtype="6" enumb="4">
       <action>
         <libid>1</libid>
         <id>603</id>


### PR DESCRIPTION
Addressed issue #6 in GitHub issue tracking. Fixed mouse button event,
changed to mouse press event in display_obj
